### PR TITLE
Introduce core.ReturnOutputs

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -3,7 +3,7 @@ from morphocut.io import ImageReader, ImageWriter
 
 with Pipeline() as p:
     # TODO: Work on many images
-    image = ImageReader("/path/to/input.png")()
+    image = ImageReader("/path/to/input.png")
     ImageWriter("/path/to/output.png", image)
 
 p.run()

--- a/examples/video.py
+++ b/examples/video.py
@@ -4,8 +4,8 @@ from morphocut.pims import VideoReader
 from morphocut.str import Format
 
 with Pipeline() as p:
-    image, frame_number = VideoReader("/path/to/video.avi")()
-    filename = Format("/output/path/frame_#{}.png", frame_number)()
+    image, frame_number = VideoReader("/path/to/video.avi")
+    filename = Format("/output/path/frame_#{}.png", frame_number)
     ImageWriter(filename, image)
 
 p.run()

--- a/experiments/cif.py
+++ b/experiments/cif.py
@@ -11,16 +11,16 @@ if __name__ == "__main__":
     with Pipeline() as p:
         input_fn = "/home/moi/Work/Datasets/06_CD20_brightfield_6.cif"
 
-        frame, series = BioformatsReader(input_fn, meta=False)()
+        frame, series = BioformatsReader(input_fn, meta=False)
 
         # Every second frame is in fact a mask
         # TODO: Batch consecutive objects in the stream
 
         Slice(None, None, 2)
 
-        output_fn = Format("/tmp/cif/{}.png", series)()
+        output_fn = Format("/tmp/cif/{}.png", series)
 
-        frame = LambdaNode(rescale_intensity, frame)()
+        frame = LambdaNode(rescale_intensity, frame)
 
         LambdaNode(imsave, output_fn, frame)
 

--- a/experiments/process_kosmos_graph.py
+++ b/experiments/process_kosmos_graph.py
@@ -16,9 +16,9 @@ from morphocut.str import Format, Parse
 from morphocut.stream import TQDM, Enumerate, PrintObjects, StreamBuffer
 from morphocut.zooprocess import CalculateZooProcessFeatures
 
-#import_path = "/data-ssd/mschroeder/Datasets/generic_zooscan_peru_kosmos_2017"
+# import_path = "/data-ssd/mschroeder/Datasets/generic_zooscan_peru_kosmos_2017"
 import_path = "/home/moi/Work/0-Datasets/generic_zooscan_peru_kosmos_2017"
-#import_path = '/studi-tmp/mkhan/generic_zooscan_peru_kosmos_2017'
+# import_path = '/studi-tmp/mkhan/generic_zooscan_peru_kosmos_2017'
 
 if __name__ == "__main__":
     image_root = os.path.join(import_path, "raw")
@@ -27,45 +27,44 @@ if __name__ == "__main__":
     with Pipeline() as p:
         # Images are named <sampleid>/<anything>_<a|b>.tif
         # e.g. generic_Peru_20170226_slow_M1_dnet/Peru_20170226_M1_dnet_1_8_a.tif
-        abs_path = Find(image_root, [".tif"])()
+        abs_path = Find(image_root, [".tif"])
 
-        rel_path = LambdaNode(os.path.relpath, abs_path, image_root)()
+        rel_path = LambdaNode(os.path.relpath, abs_path, image_root)
         meta = Parse(
             "generic_{sample_id}/{:greedy}_{sample_split:d}_{sample_nsplit:d}_{sample_subid}.tif",
-            rel_path
-        )()
+            rel_path,
+        )
 
         meta = JoinMetadata(
             os.path.join(
-                import_path, "Morphocut_header_scans_peru_kosmos_2017.xlsx"
-            ),
+                import_path, "Morphocut_header_scans_peru_kosmos_2017.xlsx"),
             meta,
             "sample_id",
-        )()
+        )
 
         PandasWriter(
             os.path.join(import_path, "meta.csv"),
             meta,
             drop_duplicates_subset="sample_id",
-        )()
+        )
 
-        img = LambdaNode(skimage.io.imread, abs_path)()
+        img = LambdaNode(skimage.io.imread, abs_path)
 
         StreamBuffer(maxsize=2)
 
-        TQDM(rel_path)()
+        TQDM(rel_path)
 
-        img = Rescale(img, in_range=(9252, 65278), dtype=np.uint8)()
+        img = Rescale(img, in_range=(9252, 65278), dtype=np.uint8)
 
-        mask = ThresholdConst(img, 245)()  # 245(ubyte) / 62965(uint16)
-        mask = LambdaNode(skimage.segmentation.clear_border, mask)()
+        mask = ThresholdConst(img, 245)  # 245(ubyte) / 62965(uint16)
+        mask = LambdaNode(skimage.segmentation.clear_border, mask)
 
-        regionprops = FindRegions(mask, img, 100, padding=10)()
+        regionprops = FindRegions(mask, img, 100, padding=10)
 
         # TODO: Draw object info
 
         # Extract a vignette from the image
-        vignette = ExtractROI(img, regionprops)()
+        vignette = ExtractROI(img, regionprops)
 
         # # Extract features from vignette
         # model = resnet18(pretrained=True)
@@ -74,20 +73,20 @@ if __name__ == "__main__":
 
         # features = PyTorch(lambda x: model(x).cpu().numpy())(vignette)
 
-        i = Enumerate()()
+        i = Enumerate()
         object_id = Format(
             "{sample_id}_{sample_split:d}_{sample_nsplit:d}_{sample_subid}_{i:d}",
             _kwargs=meta,
             i=i,
-        )()
+        )
         meta["object_id"] = object_id
-        meta = CalculateZooProcessFeatures(regionprops, meta, "object_")()
+        meta = CalculateZooProcessFeatures(regionprops, meta, "object_")
 
         # EcotaxaWriter(
         #     os.path.join(import_path, "export.zip"), "{object_id}.jpg",
         #     vignette, meta
-        # )()
+        # )
 
-        TQDM(object_id)()
+        TQDM(object_id)
 
     p.run()

--- a/morphocut/__init__.py
+++ b/morphocut/__init__.py
@@ -1,5 +1,5 @@
 from ._version import get_versions
-from .core import LambdaNode, Node, Output, Pipeline
+from .core import LambdaNode, Node, Output, Pipeline, ReturnOutputs
 
 __version__ = get_versions()['version']
 del get_versions

--- a/morphocut/core.py
+++ b/morphocut/core.py
@@ -2,7 +2,9 @@
 
 import inspect
 import operator
+import typing as T
 import warnings
+from functools import wraps
 
 _pipeline_stack = []
 
@@ -15,10 +17,7 @@ def _resolve_variable(obj, variable_or_value):
         return tuple(_resolve_variable(obj, v) for v in variable_or_value)
 
     if isinstance(variable_or_value, dict):
-        return {
-            k: _resolve_variable(obj, v)
-            for k, v in variable_or_value.items()
-        }
+        return {k: _resolve_variable(obj, v) for k, v in variable_or_value.items()}
 
     return variable_or_value
 
@@ -34,7 +33,8 @@ class Node:
 
         # Register with pipeline
         try:
-            _pipeline_stack[-1]._add_node(self)  # pylint: disable=protected-access
+            _pipeline_stack[-1]._add_node(
+                self)  # pylint: disable=protected-access
         except IndexError:
             raise RuntimeError("Empty pipeline stack") from None
 
@@ -44,15 +44,16 @@ class Node:
 
         return variable
 
-    def __call__(self):
+    def __call__(self) -> T.Union[Variable, T.Tuple[Variable]]:
         """Return outputs."""
 
         try:
             outputs = self.__dict__["outputs"]
         except KeyError:
             raise RuntimeError(
-                "'{type}' is not initialized properly. Did you forget a super().__init__() in the constructor?"
-                .format(type=type(self).__name__)
+                "'{type}' is not initialized properly. Did you forget a super().__init__() in the constructor?".format(
+                    type=type(self).__name__
+                )
             )
 
         self._outputs_retrieved = True
@@ -73,8 +74,7 @@ class Node:
             return _resolve_variable(obj, getattr(self, names))
 
         return tuple(
-            _resolve_variable(obj, v)
-            for v in (getattr(self, n) for n in names)
+            _resolve_variable(obj, v) for v in (getattr(self, n) for n in names)
         )
 
     def prepare_output(self, obj, *values):
@@ -97,8 +97,9 @@ class Node:
                     values = values[0]
                     continue
                 raise ValueError(
-                    "Length of values does not match number of output ports: {} vs. {}"
-                    .format(n_values, n_outputs)
+                    "Length of values does not match number of output ports: {} vs. {}".format(
+                        n_values, n_outputs
+                    )
                 )
             break
 
@@ -110,7 +111,7 @@ class Node:
     def after_stream(self):
         """
         Do something after the stream was processed.
-        
+
         Called by transform_stream after stream processing is done.
         Override this in your own implementation.
         """
@@ -120,7 +121,9 @@ class Node:
         """Inspect self.transform to get the parameter names."""
         return [
             p.name
-            for p in inspect.signature(self.transform).parameters.values()  # pylint: disable=no-member
+            for p in inspect.signature(
+                self.transform
+            ).parameters.values()  # pylint: disable=no-member
             if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
         ]
 
@@ -129,8 +132,9 @@ class Node:
 
         if not self._outputs_retrieved:
             warnings.warn(
-                "Outputs were not retrieved. Did you forget a () after {type}(...)?"
-                .format(type=type(self).__name__)
+                "Outputs were not retrieved. Did you forget a () after {type}(...)?".format(
+                    type=type(self).__name__
+                )
             )
 
         names = self._get_parameter_names()
@@ -149,19 +153,6 @@ class Node:
     def __str__(self):
         return "{}()".format(self.__class__.__name__)
 
-    def __getattr__(self, name):
-        if name == "transform":
-            raise AttributeError(
-                "'{type}' has no attribute '{name}'".format(
-                    type=type(self).__name__, name=name
-                )
-            )
-
-        raise AttributeError(
-            "'{type}' has no attribute '{name}'. Did you forget a () after {type}(...)?"
-            .format(type=type(self).__name__, name=name)
-        )
-
 
 class Output:
     """Stores meta data about a output of a Node.
@@ -169,6 +160,7 @@ class Output:
     This is used as a decorator.
 
     Example:
+        @ReturnOutputs
         @Output("bar")
         class Foo(Node):
             ...
@@ -186,9 +178,7 @@ class Output:
         return Variable(self.name, node)
 
     def __repr__(self):
-        return "{}(\"{}\", {})".format(
-            self.__class__.__name__, self.name, self.node_cls
-        )
+        return '{}("{}", {})'.format(self.__class__.__name__, self.name, self.node_cls)
 
     def __call__(self, cls):
         """Add this output to the list of a nodes outputs."""
@@ -210,6 +200,20 @@ class Output:
         return cls
 
 
+def ReturnOutputs(node_cls):
+    if not issubclass(node_cls, Node):
+        raise ValueError(
+            "This decorator is meant to be applied to a subclass of Node."
+        )
+
+    @wraps(node_cls)
+    def wrapper(*args, **kwargs) -> T.Union[Variable, T.Tuple[Variable]]:
+        return node_cls(*args, **kwargs)()
+    wrapper.node_cls = node_cls
+    return wrapper
+
+
+@ReturnOutputs
 @Output("out")
 class LambdaNode(Node):
     """
@@ -222,7 +226,7 @@ class LambdaNode(Node):
 
     Output:
         The result of the function application.
-        
+
     """
 
     def __init__(self, clbl, *args, **kwargs):
@@ -247,17 +251,16 @@ class Variable:
         self.node = node
 
     def __getattr__(self, name):
-        return LambdaNode(getattr, self, name)()
+        return LambdaNode(getattr, self, name)
 
     def __getitem__(self, key):
-        return LambdaNode(operator.getitem, self, key)()
+        return LambdaNode(operator.getitem, self, key)
 
     def __setitem__(self, key, value):
-        return LambdaNode(operator.setitem, self, key, value)()
+        return LambdaNode(operator.setitem, self, key, value)
 
 
 class Pipeline:
-
     def __init__(self):
         self.nodes = []
 

--- a/morphocut/ecotaxa.py
+++ b/morphocut/ecotaxa.py
@@ -14,9 +14,9 @@ import zipfile
 import PIL
 
 from morphocut._optional import import_optional_dependency
-from morphocut import Node
+from morphocut import Node, ReturnOutputs
 
-
+@ReturnOutputs
 class EcotaxaWriter(Node):
     """Zip the image and its meta data."""
 
@@ -77,6 +77,6 @@ class EcotaxaWriter(Node):
                 dataframe.to_csv(sep='\t', encoding='utf-8', index=False)
             )
 
-
+@ReturnOutputs
 class EcotaxaReader(Node):
     ...

--- a/morphocut/file.py
+++ b/morphocut/file.py
@@ -1,8 +1,8 @@
 import os
 
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
-
+@ReturnOutputs
 @Output("abs_path")
 class Find(Node):
     """

--- a/morphocut/image.py
+++ b/morphocut/image.py
@@ -7,9 +7,10 @@ import scipy.ndimage as ndi
 import skimage.exposure
 import skimage.io
 
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
 
+@ReturnOutputs
 @Output("mask")
 class ThresholdConst(Node):
     """Set the mask of image
@@ -31,6 +32,7 @@ class ThresholdConst(Node):
         return mask
 
 
+@ReturnOutputs
 @Output("rescaled")
 class Rescale(Node):
     """Rescale the image
@@ -58,6 +60,7 @@ class Rescale(Node):
         return image
 
 
+@ReturnOutputs
 class ImageWriter(Node):
     """Create a duplicate image, return its directory and filename
     """
@@ -91,6 +94,7 @@ class ImageWriter(Node):
             yield dirname, filename, image, obj
 
 
+@ReturnOutputs
 @Output("regionprops")
 class FindRegions(Node):
     """
@@ -104,10 +108,10 @@ class FindRegions(Node):
     Example:
         .. code-block:: python
             mask = ...
-            regionsprops = FindRegions(mask)()
+            regionsprops = FindRegions(mask)
 
             # regionsprops: A skimage.measure.regionsprops object.
-    
+
     """
 
     def __init__(
@@ -157,6 +161,7 @@ class FindRegions(Node):
                 yield self.prepare_output(obj.copy(), props)
 
 
+@ReturnOutputs
 @Output("extracted_image")
 class ExtractROI(Node):
     """Return the extracted region/image
@@ -174,6 +179,7 @@ class ExtractROI(Node):
         return image[regionprops.slice]
 
 
+@ReturnOutputs
 class ImageStats(Node):
     """
     Parse information from a path

--- a/morphocut/io.py
+++ b/morphocut/io.py
@@ -1,9 +1,10 @@
 import numpy as np
 import PIL
 
-from morphocut import Node
+from morphocut import, ReturnOutputs
 
 
+@ReturnOutputs
 class ImageReader(Node):
     def __init__(self, path):
         super().__init__()
@@ -18,6 +19,7 @@ class ImageReader(Node):
             yield self.prepare_output(obj, image)
 
 
+@ReturnOutputs
 class ImageWriter(Node):
     def __init__(self, path, image):
         super().__init__()

--- a/morphocut/pandas.py
+++ b/morphocut/pandas.py
@@ -2,13 +2,14 @@ import csv
 import os
 
 from morphocut._optional import import_optional_dependency
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
 
 def _default_writer(dataframe, path_or_buf):
     dataframe.to_csv(path_or_buf, index=False)
 
 
+@ReturnOutputs
 class PandasWriter(Node):
     """Create a duplicate file and dumps metadata here."""
 
@@ -49,6 +50,7 @@ class PandasWriter(Node):
         self.writer(dataframe, self.path_or_buf)
 
 
+@ReturnOutputs
 @Output("meta_out")
 class JoinMetadata(Node):
     """Join information from a CSV/TSV/Excel/... file."""

--- a/morphocut/pims.py
+++ b/morphocut/pims.py
@@ -10,9 +10,10 @@ Through PIMS, MorphoCut supports reading Bioformats and Video.
 .. _PIMS: http://soft-matter.github.io/pims/stable
 """
 from morphocut._optional import import_optional_dependency
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
 
+@ReturnOutputs
 @Output("frame")
 class VideoReader(Node):
     """Read frames from video files.
@@ -21,7 +22,7 @@ class VideoReader(Node):
         `PyAV`_ is required to use this reader.
 
         .. _PyAV: https://docs.mikeboers.com/pyav/develop/installation.html
-        
+
 
     Args:
         path: Path to a video file.
@@ -30,7 +31,7 @@ class VideoReader(Node):
     Example:
         .. code-block:: python
 
-            frame = VideoReader(path)()
+            frame = VideoReader(path)
 
             # frame (pims.Frame): The frame.
             #   frame.frame_no (int): Frame number.
@@ -54,6 +55,7 @@ class VideoReader(Node):
                 yield self.prepare_output(obj.copy(), frame)
 
 
+@ReturnOutputs
 @Output("frame")
 @Output("series")
 class BioformatsReader(Node):
@@ -81,7 +83,7 @@ class BioformatsReader(Node):
     Example:
         .. code-block:: python
 
-            frame, series = BioformatsReader(path)()
+            frame, series = BioformatsReader(path)
 
             # frame (pims.Frame): The frame.
             #   frame.frame_no (int): Frame number.

--- a/morphocut/str.py
+++ b/morphocut/str.py
@@ -1,9 +1,10 @@
 from morphocut._optional import import_optional_dependency
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 from morphocut.core import Variable
 import warnings
 
 
+@ReturnOutputs
 @Output("string")
 class Format(Node):
     """Format a string just like :py:meth:`str.format`."""
@@ -27,6 +28,7 @@ class ParseWarning(UserWarning):
     """Issued by :py:class:`Parse`."""
 
 
+@ReturnOutputs
 @Output("meta")
 class Parse(Node):
     """Parse information from a path.

--- a/morphocut/stream.py
+++ b/morphocut/stream.py
@@ -8,11 +8,12 @@ from queue import Queue
 from threading import Thread
 
 from morphocut._optional import import_optional_dependency
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
 __all__ = ["TQDM", "Slice"]
 
 
+@ReturnOutputs
 class TQDM(Node):
     """
     Provide a progress indicator via `tqdm`_.
@@ -38,6 +39,7 @@ class TQDM(Node):
         progress.close()
 
 
+@ReturnOutputs
 class Slice(Node):
 
     def __init__(self, *args):
@@ -49,6 +51,7 @@ class Slice(Node):
             yield obj
 
 
+@ReturnOutputs
 class StreamBuffer(Node):
     """
     Buffer the stream.
@@ -86,6 +89,7 @@ class StreamBuffer(Node):
         thread.join()
 
 
+@ReturnOutputs
 class PrintObjects(Node):
 
     def __init__(self, *args):
@@ -101,6 +105,7 @@ class PrintObjects(Node):
             yield obj
 
 
+@ReturnOutputs
 @Output("index")
 class Enumerate(Node):
 
@@ -109,6 +114,7 @@ class Enumerate(Node):
             yield self.prepare_output(obj, i)
 
 
+@ReturnOutputs
 @Output("value")
 class FromIterable(Node):
     """Insert values from the supplied iterator into the stream."""

--- a/morphocut/torch.py
+++ b/morphocut/torch.py
@@ -1,6 +1,7 @@
-from morphocut import Node, Output
-from morphocut._optional import import_optional_dependency
 import typing as T
+
+from morphocut import Node, Output, ReturnOutputs
+from morphocut._optional import import_optional_dependency
 
 
 class _Envelope:
@@ -10,6 +11,7 @@ class _Envelope:
         self.data = data
 
 
+@ReturnOutputs
 @Output("output")
 class PyTorch(Node):
 

--- a/morphocut/zooprocess.py
+++ b/morphocut/zooprocess.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 
-from morphocut import Node, Output
+from morphocut import Node, Output, ReturnOutputs
 
 
 def regionprop2zooprocess(prop):
@@ -82,6 +82,7 @@ def regionprop2zooprocess(prop):
     }
 
 
+@ReturnOutputs
 @Output("meta")
 class CalculateZooProcessFeatures(Node):
     """Calculate descriptive features using skimage.measure.regionprops.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,13 @@
-from morphocut import Node, Pipeline, Output
+from morphocut import Node, Pipeline, Output, ReturnOutputs
 import pytest
 
 
+@ReturnOutputs
 class TestNodeNoTransform(Node):
     pass
 
 
+@ReturnOutputs
 @Output("a")
 @Output("b")
 @Output("c")
@@ -35,7 +37,7 @@ def test_Node():
 
     # Assert that parameters and outputs are passed as expected
     with Pipeline() as pipeline:
-        a, b, c = TestNode(1, 2, 3)()
+        a, b, c = TestNode(1, 2, 3)
 
     obj, *_ = list(pipeline.transform_stream())
     assert obj[a] == 1

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -21,7 +21,7 @@ def test_Format():
     kwargs = {"c": 9, "d": 10}
 
     with Pipeline() as pipeline:
-        result = Format(fmt, *args, _args=_args, _kwargs=_kwargs, **kwargs)()
+        result = Format(fmt, *args, _args=_args, _kwargs=_kwargs, **kwargs)
 
     stream = pipeline.transform_stream()
     obj = next(stream)
@@ -34,7 +34,7 @@ def test_Format():
     kwargs = {"a": 3, "b": 4}
 
     with Pipeline() as pipeline:
-        result = Format(fmt, _kwargs=_kwargs, **kwargs)()
+        result = Format(fmt, _kwargs=_kwargs, **kwargs)
 
     stream = pipeline.transform_stream()
     obj = next(stream)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -16,7 +16,7 @@ def test_TQDM():
     obj = list(stream)
 
     assert obj == [0, 1, 2, 3, 4]
-    assert result.description == 'Description'
+    assert result.description == "Description"
 
 
 def test_Slice():
@@ -29,7 +29,7 @@ def test_Slice():
     stream = pipeline.transform_stream(items)
     obj = list(stream)
 
-    assert obj == ['A', 'B']
+    assert obj == ["A", "B"]
 
     # Assert that the stream is sliced from the specified start and end
     with Pipeline() as pipeline:
@@ -38,7 +38,7 @@ def test_Slice():
     stream = pipeline.transform_stream(items)
     obj = list(stream)
 
-    assert obj == ['C', 'D']
+    assert obj == ["C", "D"]
 
 
 def test_StreamBuffer():
@@ -52,18 +52,18 @@ def test_StreamBuffer():
     stream = result.transform_stream(items)
     obj = list(stream)
 
-    assert obj[0] == '1'
-    assert obj[1] == '2'
-    assert obj[2] == '3'
-    assert obj[3] == '4'
-    assert obj[4] == '5'
+    assert obj[0] == "1"
+    assert obj[1] == "2"
+    assert obj[2] == "3"
+    assert obj[3] == "4"
+    assert obj[4] == "5"
 
 
 def test_FromIterable():
     values = list(range(10))
 
     with Pipeline() as pipeline:
-        value = FromIterable(values)()
+        value = FromIterable(values)
 
     stream = pipeline.transform_stream()
 
@@ -76,8 +76,8 @@ def test_PrintObjects():
     values = list(range(10))
 
     with Pipeline() as pipeline:
-        value = FromIterable(values)()
-        PrintObjects(value)()
+        value = FromIterable(values)
+        PrintObjects(value)
 
     # TODO: Capture output and compare
 


### PR DESCRIPTION
It is no longer necessary to write empty parentheses () to get the outputs of a node.