### PR TITLE
Profile: Measure the lead time of object in the pipeline

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ User Guide
    stream
    parallel
    formats
+   profiling
    core
    contrib
    contributing

--- a/docs/profiling.rst
+++ b/docs/profiling.rst
@@ -1,0 +1,9 @@
+Profiling
+=========
+
+:py:class:`~morphocut.profile.Profile` enables the measurement of the time
+an object spends inside certain parts of the pipeline.
+
+.. autoclass:: morphocut.profile.Profile
+    :members:
+    :exclude-members: transform_stream

--- a/src/morphocut/core.py
+++ b/src/morphocut/core.py
@@ -4,8 +4,10 @@ import inspect
 import operator
 from abc import ABC, abstractmethod
 from collections import abc
+from contextlib import contextmanager
 from functools import wraps
 from typing import (
+    Any,
     Callable,
     Dict,
     Generic,
@@ -24,6 +26,9 @@ _pipeline_stack = []  # type: List[Pipeline] # pylint: disable=invalid-name
 class StreamTransformer(ABC):
     """ABC for stream transformers like Pipeline and Node."""
 
+    def __init__(self):
+        self.id = "{:x}".format(id(self))
+
     @abstractmethod
     def transform_stream(self, stream):
         while False:
@@ -35,9 +40,6 @@ class StreamTransformer(ABC):
             if any("transform_stream" in B.__dict__ for B in C.__mro__):
                 return True
         return NotImplemented
-
-
-from contextlib import contextmanager
 
 
 @contextmanager
@@ -78,7 +80,8 @@ class Variable(Generic[T]):
 
     Attributes:
         name: The name of the Variable.
-        node: The node that created the Variable.
+        parent: The parent that created the Variable.
+            This is just used in the string representation.
 
     Operations:
         Variables support the following operations.
@@ -158,15 +161,15 @@ class Variable(Generic[T]):
         :py:class:`Variable` instances or raw values.
     """
 
-    __slots__ = ["name", "node", "hash"]
+    __slots__ = ["name", "parent", "hash"]
 
-    def __init__(self, name: str, node: "Node"):
+    def __init__(self, name: str, parent: Any):
         self.name = name
-        self.node = node
-        self.hash = hash((node.id, name))
+        self.parent = parent
+        self.hash = hash((parent.id, name))
 
     def __str__(self):
-        return "<Variable {}.{}>".format(self.node, self.name)
+        return "<Variable {}.{}>".format(self.parent, self.name)
 
     def __repr__(self):
         return self.__str__()
@@ -365,7 +368,7 @@ class Node(StreamTransformer):
     """Base class for all stream processing nodes."""
 
     def __init__(self):
-        self.id = "{:x}".format(id(self))
+        super().__init__()
 
         # Bind outputs to self
         outputs = getattr(self.__class__, "outputs", [])
@@ -682,6 +685,8 @@ class Pipeline(StreamTransformer):
     """
 
     def __init__(self, parent: Optional["Pipeline"] = None):
+        super().__init__()
+
         self.children = []  # type: List[StreamTransformer]
 
         if parent is not None:

--- a/src/morphocut/profile.py
+++ b/src/morphocut/profile.py
@@ -1,0 +1,76 @@
+from typing import Optional
+
+from morphocut.core import Pipeline, Stream, StreamObject, Variable
+from time import perf_counter
+
+SI_PREFIXES = ["", "m", "μ", "n"]
+
+
+class Profile(Pipeline):
+    """
+    Profile pipeline nodes.
+
+    The average lead time of objects in this pipeline context is measured
+    and printed after the end of processing.
+
+    Args:
+        name (str): The name of this profiling operation.
+
+    Example:
+        .. code-block:: python
+
+            with Pipeline() as pipeline:
+                # Un-profiled processing
+                ...
+                with Profile("some name"):
+                    # Profiled processing
+                    ...
+
+            pipeline.run()
+    """
+
+    def __init__(self, name):
+        super().__init__()
+
+        self.name = name
+        self._start = Variable("_sentinel", self)
+        self._average = 0
+        self._n = 0
+
+    def _insert_sentinel(self, stream: Stream) -> Stream:
+        for obj in stream:
+            obj[self._start] = perf_counter()
+            yield obj
+
+    def _format_average(self):
+        value = self._average
+
+        for prefix in SI_PREFIXES:
+            if value > 1:
+                break
+            value *= 1000
+
+        return f"{value:.2f}{prefix}s"
+
+    def transform_stream(self, stream: Optional[Stream] = None) -> Stream:
+        if stream is None:
+            stream = [StreamObject()]
+
+        stream = self._insert_sentinel(stream)
+
+        # Here, the stream is not automatically closed,
+        # as this would happen instantaneously.
+        for child in self.children:  # type: StreamTransformer
+            stream = child.transform_stream(stream)
+
+        for obj in stream:
+            diff = perf_counter() - obj.pop(self._start)
+
+            self._n += 1
+            self._average = self._average + (diff - self._average) / self._n
+
+            yield obj
+
+        print(
+            f"Profile {self.name}: {self._n:,d} objects, avg. {self._format_average()}"
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,9 @@
-from morphocut import Node, Output, ReturnOutputs
-from skimage.data import binary_blobs
+from time import sleep
+
 import numpy as np
+from skimage.data import binary_blobs
+
+from morphocut import Node, Output, ReturnOutputs
 
 
 @ReturnOutputs
@@ -43,3 +46,12 @@ class Const(Node):
 
     def transform(self, value):
         return value
+
+
+class Sleep(Node):
+    def __init__(self, duration=0.001):
+        super().__init__()
+        self.duration = duration
+
+    def transform(self):
+        sleep(self.duration)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,6 +1,5 @@
 """Test morphocut.parallel."""
 
-from time import sleep
 
 import pytest
 from timer_cm import Timer
@@ -8,12 +7,7 @@ from timer_cm import Timer
 from morphocut import Node, Pipeline
 from morphocut.parallel import ParallelPipeline
 from morphocut.stream import Unpack
-
-
-class Sleep(Node):
-    def transform(self):
-        sleep(0.001)
-
+from tests.helpers import Sleep
 
 N_STEPS = 31
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,26 @@
+import pytest
+from timer_cm import Timer
+
+from morphocut import Node, Pipeline
+from morphocut.profile import Profile
+from morphocut.stream import Unpack
+from tests.helpers import Sleep
+
+N = 1000
+DURATION = 0.001
+
+
+def test_Profile():
+
+    with Pipeline() as pipeline:
+        Unpack(range(N))
+        with Profile("Sleep", summary=False) as profile_sleep:
+            Sleep()
+
+    objects = list(pipeline.transform_stream())
+
+    assert len(objects) == N
+
+    overhead = profile_sleep._average - DURATION
+
+    print(f"Overhead {overhead:g}s")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -14,7 +14,7 @@ def test_Profile():
 
     with Pipeline() as pipeline:
         Unpack(range(N))
-        with Profile("Sleep", summary=False) as profile_sleep:
+        with Profile("Sleep") as profile_sleep:
             Sleep()
 
     objects = list(pipeline.transform_stream())


### PR DESCRIPTION
- core.Variable: Allow all StreamTransformers as parent
- tests.helpers: Adopt Sleep from test_parallel

closes #45

- [x] tests added
- [x] all tests pass
- [x] documentation
