### PR TITLE
contrib.ecotaxa: Close archives

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,3 +44,4 @@ Fixed
 ~~~~~
 
 - ValueError: 'version' argument is required in Sphinx directives #80
+- UnknownArchiveError: Close EcoTaxa archives (#88)

--- a/src/morphocut/contrib/ecotaxa.py
+++ b/src/morphocut/contrib/ecotaxa.py
@@ -113,6 +113,9 @@ class TarArchive(Archive):
         self._tar = tarfile.open(archive_fn, mode)
         self._members = None
 
+    def close(self):
+        self._tar.close()
+
     def read_member(self, member_fn):
         return self._tar.extractfile(self._resolve_member(member_fn))
 
@@ -166,6 +169,9 @@ class ZipArchive(Archive):
             return self._zip.writestr(member_fn, fileobj_or_bytes)
 
         self._zip.writestr(member_fn, fileobj_or_bytes.read())
+
+    def close(self):
+        self._zip.close()
 
 
 @ReturnOutputs

--- a/tests/contrib/test_ecotaxa.py
+++ b/tests/contrib/test_ecotaxa.py
@@ -1,3 +1,5 @@
+import tarfile
+import zipfile
 from numpy.testing import assert_equal
 
 from morphocut import Call, Pipeline
@@ -11,7 +13,7 @@ import pytest
 
 @pytest.mark.parametrize("ext", [".tar", ".zip"])
 def test_ecotaxa(tmp_path, ext):
-    archive_fn = tmp_path / ("ecotaxa" + ext)
+    archive_fn = str(tmp_path / ("ecotaxa" + ext))
     print(archive_fn)
 
     # Create an archive
@@ -32,7 +34,13 @@ def test_ecotaxa(tmp_path, ext):
             sample_meta={"foo": 3},
         )
 
+    # Execute pipeline and collect results
     result = [o.to_dict(meta=meta, image=image) for o in p.transform_stream()]
+
+    if ext == ".zip":
+        assert zipfile.is_zipfile(archive_fn), f"{archive_fn} is not a zip file"
+    elif ext == ".tar":
+        assert tarfile.is_tarfile(archive_fn), f"{archive_fn} is not a tar file"
 
     # Read the archive
     with Pipeline() as p:


### PR DESCRIPTION
Fixes ecotaxa tests.

- [ ] tests added
- [ ] all tests pass
- [ ] documentation
- [ ] AUTHORS entry
- [x] Changelog entry
