### PR TITLE
contrib/ecotaxa: Improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ Added
 Changed
 ~~~~~~~
 
+- EcotaxaReader: Return EcotaxaObject. (#102)
+
 - EcotaxaWriter: Allow Variables for `archive_fn`. (#100)
 
 - Use `UnavailableObject` instead of `import_optional_dependency`.

--- a/src/morphocut/contrib/ecotaxa.py
+++ b/src/morphocut/contrib/ecotaxa.py
@@ -94,7 +94,7 @@ class Archive:
     def read_member(self, member_fn) -> IO:
         """
         Raises:
-            MemberNotFoundError if a member was not found
+            MemberNotFoundError: if a member was not found
         """
         raise NotImplementedError()
 
@@ -442,6 +442,16 @@ class EcotaxaWriter(Node):
 
 
 class EcotaxaObject:
+    """
+    Attributes:
+        meta (Mapping): Object metadata
+        index_fn (str, optional): Source index filename inside the archive.
+        archive_fn (str, optional): Sourche archive filename.
+        default_mode (str, optional): Default mode for image loading.
+                See `PIL Modes <https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes>`_.
+
+    """
+
     __slots__ = ["meta", "_image_data", "index_fn", "archive_fn", "default_mode"]
 
     def __init__(
@@ -518,7 +528,7 @@ class EcotaxaReader(Node):
             and returns a modified version.
 
     Returns:
-        object: A :class:`EcotaxaObject` that allows to access image(s) and metadata.
+        object: An :class:`EcotaxaObject` that allows to access image(s) and metadata.
 
     To read multiple image ranks, provide a tuple of ints as ``img_rank``.
     The first output will then be a tuple of images.
@@ -534,7 +544,7 @@ class EcotaxaReader(Node):
         .. code-block:: python
 
             with Pipeline() as p:
-                image, meta = EcotaxaReader("path/to/archive.zip")
+                obj = EcotaxaReader("path/to/archive.zip")
             p.transform_stream()
     """
 

--- a/tests/contrib/test_ecotaxa.py
+++ b/tests/contrib/test_ecotaxa.py
@@ -3,7 +3,7 @@ import zipfile
 from numpy.testing import assert_equal
 
 from morphocut import Call, Pipeline
-from morphocut.contrib.ecotaxa import EcotaxaReader, EcotaxaWriter
+from morphocut.contrib.ecotaxa import Archive, EcotaxaReader, EcotaxaWriter
 from morphocut.str import Format
 from morphocut.stream import Unpack
 from tests.helpers import BinaryBlobs
@@ -12,7 +12,8 @@ import pytest
 
 
 @pytest.mark.parametrize("ext", [".tar", ".zip"])
-def test_ecotaxa(tmp_path, ext):
+@pytest.mark.parametrize("with_images", [True, False])
+def test_ecotaxa(tmp_path, ext, with_images):
     archive_fn = str(tmp_path / ("ecotaxa" + ext))
     print(archive_fn)
 
@@ -26,9 +27,11 @@ def test_ecotaxa(tmp_path, ext):
         image = BinaryBlobs()
         image_name = Format("image_{}.png", i)
 
+        fnames_images = (image_name, image) if with_images else []
+
         EcotaxaWriter(
             archive_fn,
-            (image_name, image),
+            fnames_images,
             meta,
             object_meta={"foo": 0},
             acq_meta={"foo": 1},
@@ -60,6 +63,7 @@ def test_ecotaxa(tmp_path, ext):
             i for _ in roundtrip_result
         ]
 
-    assert_equal(
-        [o["image"] for o in result], [o["obj"].image for o in roundtrip_result]
-    )
+    if with_images:
+        assert_equal(
+            [o["image"] for o in result], [o["obj"].image for o in roundtrip_result]
+        )

--- a/tests/contrib/test_ecotaxa.py
+++ b/tests/contrib/test_ecotaxa.py
@@ -13,16 +13,16 @@ import pytest
 
 @pytest.mark.parametrize("ext", [".tar", ".zip"])
 def test_ecotaxa(tmp_path, ext):
-    archive_pat = str(tmp_path / ("ecotaxa_{:d}" + ext))
-    archive_fns = [archive_pat.format(i) for i in range(2)]
-    print(archive_fns)
+    archive_fn = str(tmp_path / ("ecotaxa" + ext))
+    print(archive_fn)
 
     # Create an archive
     with Pipeline() as p:
-        archive_fn = Unpack(archive_fns)
         i = Unpack(range(10))
 
-        meta = Call(dict, i=i, foo="Sömé UTF-8 ſtríng…")
+        object_id = Format("foo{:d}", i)
+
+        meta = Call(dict, object_id=object_id, i=i, foo="Sömé UTF-8 ſtríng…")
         image = BinaryBlobs()
         image_name = Format("image_{}.png", i)
 
@@ -39,22 +39,20 @@ def test_ecotaxa(tmp_path, ext):
     # Execute pipeline and collect results
     result = [o.to_dict(meta=meta, image=image) for o in p.transform_stream()]
 
-    for archive_fn in archive_fns:
-        if ext == ".zip":
-            assert zipfile.is_zipfile(archive_fn), f"{archive_fn} is not a zip file"
-        elif ext == ".tar":
-            assert tarfile.is_tarfile(archive_fn), f"{archive_fn} is not a tar file"
+    if ext == ".zip":
+        assert zipfile.is_zipfile(archive_fn), f"{archive_fn} is not a zip file"
+    elif ext == ".tar":
+        assert tarfile.is_tarfile(archive_fn), f"{archive_fn} is not a tar file"
 
     # Read the archive
     with Pipeline() as p:
-        archive_fn = Unpack(archive_fns)
-        image, meta = EcotaxaReader(archive_fn)
+        obj = EcotaxaReader(archive_fn)
 
-    roundtrip_result = [o.to_dict(meta=meta, image=image) for o in p.transform_stream()]
+    roundtrip_result = [o.to_dict(obj=obj) for o in p.transform_stream()]
 
     for meta_field in ("i", "foo"):
         assert [o["meta"][meta_field] for o in result] == [
-            o["meta"][meta_field] for o in roundtrip_result
+            o["obj"].meta[meta_field] for o in roundtrip_result
         ]
 
     for i, prefix in enumerate(("object_", "acq_", "process_", "sample_")):
@@ -62,4 +60,6 @@ def test_ecotaxa(tmp_path, ext):
             i for _ in roundtrip_result
         ]
 
-    assert_equal([o["image"] for o in result], [o["image"] for o in roundtrip_result])
+    assert_equal(
+        [o["image"] for o in result], [o["obj"].image for o in roundtrip_result]
+    )


### PR DESCRIPTION
- Variable compression
- Write only metadata (no images)
- EcotaxaReader: Return EcotaxaObject object
- EcotaxaObject: Filehandle for image data (for efficient copying)

closes #xxxx

- [x] tests added
- [x] all tests pass
- [x] documentation
- [x] AUTHORS entry
- [x] Changelog entry


<!-- readthedocs-preview morphocut start -->
----
:books: Documentation preview :books:: https://morphocut--102.org.readthedocs.build/en/102/

<!-- readthedocs-preview morphocut end -->