### PR TITLE
enh(stream.Slice): Provide n_remaining_hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ docs/inventory/
 *.code-workspace
 .coverage.*
 .venv/
+experiments/*
 coverage.xml
+*.tmp

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,3 +53,4 @@ Fixed
 
 - ValueError: 'version' argument is required in Sphinx directives #80
 - UnknownArchiveError: Close EcoTaxa archives (#88)
+- wrongly reported n_remaining_hint in Progress after Slice (#105)

--- a/src/morphocut/stream.py
+++ b/src/morphocut/stream.py
@@ -106,6 +106,10 @@ class Slice(Node):
     def transform_stream(self, stream: Stream):
         with closing_if_closable(stream):
             for obj in itertools.islice(stream, *self.args):
+                if obj.n_remaining_hint is not None:
+                    obj.n_remaining_hint = len(
+                        range(*slice(*self.args).indices(obj.n_remaining_hint))
+                    )
                 yield obj
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -47,21 +47,23 @@ def test_Slice():
     items = "ABCDEFG"
 
     with Pipeline() as pipeline:
+        item = Unpack(items)
         result = Slice(2)
 
-    stream = pipeline.transform_stream(items)
-    obj = list(stream)
+    stream = pipeline.transform_stream()
+    result = [obj[item] for obj in stream]
 
-    assert obj == ["A", "B"]
+    assert result == ["A", "B"]
 
     # Assert that the stream is sliced from the specified start and end
     with Pipeline() as pipeline:
+        item = Unpack(items)
         result = Slice(2, 4)
 
-    stream = pipeline.transform_stream(items)
-    obj = list(stream)
+    stream = pipeline.transform_stream()
+    result = [obj[item] for obj in stream]
 
-    assert obj == ["C", "D"]
+    assert result == ["C", "D"]
 
 
 def test_StreamBuffer():


### PR DESCRIPTION
This fixes wrongly reported n_remaining_hint in Progress after Slice.

- [ ] tests added
- [x] all tests pass
- [ ] documentation
- [ ] AUTHORS entry
- [x] Changelog entry


<!-- readthedocs-preview morphocut start -->
----
:books: Documentation preview :books:: https://morphocut--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview morphocut end -->