### PR TITLE
Fix calculation of n_remaining_hint in stream.Slice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,10 @@ Removed
 Fixed
 ~~~~~
 
-- ValueError: 'version' argument is required in Sphinx directives #80
-- UnknownArchiveError: Close EcoTaxa archives (#88)
-- wrongly reported n_remaining_hint in Progress after Slice (#105)
+- calculation of `n_remaining_hint` in `stream.Slice` (#111). 
+
+- ValueError: 'version' argument is required in Sphinx directives (#80).
+
+- UnknownArchiveError: Close EcoTaxa archives (#88).
+
+- wrongly reported n_remaining_hint in Progress after Slice (#105).

--- a/src/morphocut/stream.py
+++ b/src/morphocut/stream.py
@@ -105,10 +105,16 @@ class Slice(Node):
 
     def transform_stream(self, stream: Stream):
         with closing_if_closable(stream):
-            for obj in itertools.islice(stream, *self.args):
+            for n_seen, obj in enumerate(itertools.islice(stream, *self.args)):
                 if obj.n_remaining_hint is not None:
-                    obj.n_remaining_hint = len(
-                        range(*slice(*self.args).indices(obj.n_remaining_hint))
+                    # Slice into the total number of objects (n_seen + remaining)
+                    n_total = len(
+                        range(*slice(*self.args).indices(obj.n_remaining_hint + n_seen))
+                    )
+                    # Subtract n_seen to get remaining
+                    obj.n_remaining_hint = max(
+                        0,
+                        n_total - n_seen,
                     )
                 yield obj
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -50,20 +50,24 @@ def test_Slice():
         item = Unpack(items)
         result = Slice(2)
 
-    stream = pipeline.transform_stream()
+    stream = list(pipeline.transform_stream())
     result = [obj[item] for obj in stream]
+    n_remaining = [obj.n_remaining_hint for obj in stream]
 
     assert result == ["A", "B"]
+    assert n_remaining == [2, 1]
 
     # Assert that the stream is sliced from the specified start and end
     with Pipeline() as pipeline:
         item = Unpack(items)
         result = Slice(2, 4)
 
-    stream = pipeline.transform_stream()
+    stream = list(pipeline.transform_stream())
     result = [obj[item] for obj in stream]
+    n_remaining = [obj.n_remaining_hint for obj in stream]
 
     assert result == ["C", "D"]
+    assert n_remaining == [2, 1]
 
 
 def test_StreamBuffer():


### PR DESCRIPTION
Fixes the calculation of `n_remaining_hint` in `stream.Slice`.

- [x] tests added
- [x] all tests pass
- [ ] documentation
- [ ] AUTHORS entry
- [x] Changelog entry


<!-- readthedocs-preview morphocut start -->
----
:books: Documentation preview :books:: https://morphocut--111.org.readthedocs.build/en/111/

<!-- readthedocs-preview morphocut end -->