### PR TITLE
Fix buffered_generator and use in StreamBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ experiments/*
 coverage.xml
 examples/*_out
 *.tmp
+.conda/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,10 @@ Added
 Changed
 ~~~~~~~
 
+- Fix `buffered_generator` (#121).
+
+- `StreamBuffer` now re-raises exceptions from the filler thread (#120).
+
 - `ecotaxa`: Return EcotaxaObject in EcotaxaReader (#102).
   Allow Variables for `archive_fn` in EcoTaxaWriter (#100).
   More improvements (#109).
@@ -40,7 +44,6 @@ Changed
 
 - Require scikit-image>=0.19 (#86)
 
-- `StreamBuffer` now re-raises exceptions from the filler thread (#120).
 
 Deprecated
 ~~~~~~~~~~

--- a/src/morphocut/stream.py
+++ b/src/morphocut/stream.py
@@ -2,10 +2,7 @@
 
 import itertools
 import pprint
-from queue import Queue
-from threading import Thread
 from typing import Callable, Collection, Optional, Union
-from morphocut.utils import StreamEstimator
 
 import tqdm
 from deprecated.sphinx import deprecated
@@ -20,6 +17,7 @@ from morphocut.core import (
     Variable,
     closing_if_closable,
 )
+from morphocut.utils import StreamEstimator, buffered_generator
 
 __all__ = [
     "Enumerate",
@@ -123,45 +121,41 @@ class Slice(Node):
 
 class StreamBuffer(Node):
     """
-    Buffer the stream.
+    A data processing node that buffers a stream to improve throughput by decoupling data
+    production from data consumption.
+
+    The `StreamBuffer` class allows for continued processing of data while I/O-bound nodes
+    are waiting for data. By buffering the stream, it enables asynchronous prefetching and
+    minimizes the time spent waiting for data to be available.
 
     Args:
-        maxsize (int): Maximum size of the buffer.
+        maxsize (int): The maximum number of items to buffer. If the buffer is full, further
+            data production is paused until items are consumed.
 
-    This allows continued processing while I/O bound Nodes wait for data.
+    Example:
+        .. code-block:: python
+
+            with Pipeline() as pipeline:
+                # Produce data (preferably I/O-bound)
+                ...
+                StreamBuffer(maxsize=100)
+                # Process data (preferably CPU-bound)
+                ...
     """
 
     _sentinel = object()
 
     def __init__(self, maxsize: int):
         super().__init__()
-        self.queue = Queue(maxsize)
-        self.exception: Optional[BaseException] = None
-
-    def _fill_queue(self, stream: Stream):
-        try:
-            with closing_if_closable(stream):
-                for obj in stream:
-                    self.queue.put(obj)
-        except BaseException as exc:
-            self.exception = exc
-        finally:
-            self.queue.put(self._sentinel)
+        self.maxsize = maxsize
 
     def transform_stream(self, stream: Stream):
-        thread = Thread(target=self._fill_queue, args=(stream,), daemon=True)
-        thread.start()
+        @buffered_generator(self.maxsize)
+        def buffered_stream():
+            with closing_if_closable(stream):
+                yield from stream
 
-        while True:
-            obj = self.queue.get()
-            if obj == self._sentinel:
-                if self.exception is not None:
-                    raise self.exception
-                break
-            yield obj
-
-        # Join _fill_queue (which should be dead by now because we received `self._sentinel`)
-        thread.join()
+        return buffered_stream()
 
 
 @ReturnOutputs

--- a/src/morphocut/stream.py
+++ b/src/morphocut/stream.py
@@ -119,6 +119,7 @@ class Slice(Node):
                 yield obj
 
 
+@ReturnOutputs
 class StreamBuffer(Node):
     """
     |stream| Buffer a stream to improve throughput by decoupling data
@@ -150,8 +151,6 @@ class StreamBuffer(Node):
         self.maxsize = maxsize
 
     def transform_stream(self, stream: Stream):
-        """"""
-
         @buffered_generator(self.maxsize)
         def buffered_stream():
             with closing_if_closable(stream):

--- a/src/morphocut/stream.py
+++ b/src/morphocut/stream.py
@@ -121,11 +121,11 @@ class Slice(Node):
 
 class StreamBuffer(Node):
     """
-    A data processing node that buffers a stream to improve throughput by decoupling data
+    |stream| Buffer a stream to improve throughput by decoupling data
     production from data consumption.
 
-    The `StreamBuffer` class allows for continued processing of data while I/O-bound nodes
-    are waiting for data. By buffering the stream, it enables asynchronous prefetching and
+    This allows for continued processing of data while I/O-bound nodes
+    are waiting for data. Buffering the stream enables asynchronous prefetching and
     minimizes the time spent waiting for data to be available.
 
     Args:
@@ -139,7 +139,7 @@ class StreamBuffer(Node):
                 # Produce data (preferably I/O-bound)
                 ...
                 StreamBuffer(maxsize=100)
-                # Process data (preferably CPU-bound)
+                # Process data
                 ...
     """
 
@@ -150,6 +150,8 @@ class StreamBuffer(Node):
         self.maxsize = maxsize
 
     def transform_stream(self, stream: Stream):
+        """"""
+
         @buffered_generator(self.maxsize)
         def buffered_stream():
             with closing_if_closable(stream):


### PR DESCRIPTION
`buffered_generator` had an issue where exceptions in the input stream where swallowed. This is now resolved.

- [x] tests added
- [x] all tests pass
- [x] documentation
- [ ] AUTHORS entry
- [x] Changelog entry


<!-- readthedocs-preview morphocut start -->
----
📚 Documentation preview 📚: https://morphocut--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview morphocut end -->